### PR TITLE
fix: gc collect before save obj if large file expected

### DIFF
--- a/src/helpers/json.py
+++ b/src/helpers/json.py
@@ -18,7 +18,9 @@ def serialize_obj(obj):
     return obj
 
 
-def save_obj_to_json(obj: BaseModel | Dict, path_filename: Path, large_file_expected: bool=False):
+def save_obj_to_json(
+    obj: BaseModel | Dict, path_filename: Path, large_file_expected: bool = True
+):
     if large_file_expected:
         gc.collect()
     json.dump(

--- a/src/pipeline_expansion/algorithm.py
+++ b/src/pipeline_expansion/algorithm.py
@@ -184,36 +184,20 @@ class ExpansionAlgorithm:
         """Update Bender cuts with new values."""
         if self.just_test:
             return None
-        save_obj_to_json(
-            sddp_response,
-            self.cache_dir_run / f"sddp_response_{ι}.json",
-            large_file_expected=True,
-        )
-        save_obj_to_json(
-            admm_response,
-            self.cache_dir_run / f"bender_cuts_{ι}.json",
-            large_file_expected=True,
-        )
+        save_obj_to_json(sddp_response, self.cache_dir_run / f"sddp_response_{ι}.json")
+        save_obj_to_json(admm_response, self.cache_dir_run / f"bender_cuts_{ι}.json")
         current_cuts = BenderCuts(
             **load_obj_from_json(self.cache_dir_run / f"bender_cuts.json")
         )
         final_cuts = BenderCuts(cuts={**current_cuts.cuts, **admm_response.cuts})
-        save_obj_to_json(
-            final_cuts,
-            self.cache_dir_run / f"bender_cuts.json",
-            large_file_expected=True,
-        )
+        save_obj_to_json(final_cuts, self.cache_dir_run / f"bender_cuts.json")
         opt_config = OptimizationConfig(
             **load_obj_from_json(self.cache_dir_run / "optimization_config.json")
         )
         opt_config.grid.cuts = opt_config.grid.cuts + [
             Cut(id=int(cut_id)) for cut_id in admm_response.cuts.keys()
         ]
-        save_obj_to_json(
-            opt_config,
-            self.cache_dir_run / "optimization_config.json",
-            large_file_expected=True,
-        )
+        save_obj_to_json(opt_config, self.cache_dir_run / "optimization_config.json")
         self.expansion_request = ExpansionRequest(
             optimization=opt_config,
             scenarios=self.expansion_request.scenarios,


### PR DESCRIPTION
# Pull Request

## Description

There is an error when we run the program in small machine when it wants to record data with memory. I added a garbage collector if large file is required to be saved. This garbage collector is called in recording big json objects after running admm and sddp.